### PR TITLE
feat: add Tavily as configurable web search provider option

### DIFF
--- a/openclawd-2026.2.3/src/agents/tools/web-search.ts
+++ b/openclawd-2026.2.3/src/agents/tools/web-search.ts
@@ -475,13 +475,25 @@ type TavilySearchResponse = {
   results?: TavilySearchResult[];
 };
 
+type TavilyConfig = {
+  apiKey?: string;
+  maxResults?: number;
+  includeRawContent?: boolean;
+};
+
+function resolveTavilyConfig(search?: WebSearchConfig): TavilyConfig {
+  if (!search || typeof search !== "object") {
+    return {};
+  }
+  const tavily = "tavily" in search ? search.tavily : undefined;
+  if (!tavily || typeof tavily !== "object") {
+    return {};
+  }
+  return tavily as TavilyConfig;
+}
+
 function resolveTavilyApiKey(search?: WebSearchConfig): string | undefined {
-  const fromConfig =
-    search && "tavily" in search && typeof search.tavily === "object" && search.tavily
-      ? typeof (search.tavily as Record<string, unknown>).apiKey === "string"
-        ? ((search.tavily as Record<string, unknown>).apiKey as string).trim()
-        : ""
-      : "";
+  const fromConfig = normalizeApiKey(resolveTavilyConfig(search).apiKey);
   const fromEnv = (process.env.TAVILY_API_KEY ?? "").trim();
   return fromConfig || fromEnv || undefined;
 }
@@ -491,18 +503,24 @@ async function runTavilySearch(params: {
   count: number;
   apiKey: string;
   timeoutSeconds: number;
+  includeRawContent?: boolean;
 }): Promise<Array<{ title: string; url: string; description: string; siteName?: string }>> {
+  const body: Record<string, unknown> = {
+    query: params.query,
+    max_results: params.count,
+    search_depth: "basic",
+  };
+  if (params.includeRawContent) {
+    body.include_raw_content = true;
+  }
+
   const res = await proxyFetch(TAVILY_SEARCH_ENDPOINT, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
+      Authorization: `Bearer ${params.apiKey}`,
     },
-    body: JSON.stringify({
-      api_key: params.apiKey,
-      query: params.query,
-      max_results: params.count,
-      search_depth: "basic",
-    }),
+    body: JSON.stringify(body),
     signal: withTimeout(undefined, params.timeoutSeconds * 1000),
   });
 
@@ -514,9 +532,9 @@ async function runTavilySearch(params: {
   const data = (await res.json()) as TavilySearchResponse;
   const results = Array.isArray(data.results) ? data.results : [];
   return results.map((entry) => ({
-    title: entry.title ?? "",
+    title: entry.title ? wrapWebContent(entry.title, "web_search") : "",
     url: entry.url ?? "",
-    description: entry.content ?? "",
+    description: entry.content ? wrapWebContent(entry.content, "web_search") : "",
     siteName: resolveSiteName(entry.url),
   }));
 }
@@ -575,6 +593,7 @@ async function runWebSearch(params: {
   freshness?: string;
   perplexityBaseUrl?: string;
   perplexityModel?: string;
+  tavilyIncludeRawContent?: boolean;
 }): Promise<Record<string, unknown>> {
   const cacheKey = normalizeCacheKey(
     params.provider === "brave"
@@ -632,6 +651,7 @@ async function runWebSearch(params: {
       count: params.count,
       apiKey: params.apiKey!,
       timeoutSeconds: params.timeoutSeconds,
+      includeRawContent: params.tavilyIncludeRawContent,
     });
     const payload = {
       query: params.query,
@@ -716,6 +736,7 @@ export function createWebSearchTool(options?: {
 
   const provider = resolveSearchProvider(search);
   const perplexityConfig = resolvePerplexityConfig(search);
+  const tavilyConfig = resolveTavilyConfig(search);
 
   const description =
     provider === "perplexity"
@@ -745,7 +766,10 @@ export function createWebSearchTool(options?: {
       const params = args as Record<string, unknown>;
       const query = readStringParam(params, "query", { required: true });
       const count =
-        readNumberParam(params, "count", { integer: true }) ?? search?.maxResults ?? undefined;
+        readNumberParam(params, "count", { integer: true }) ??
+        (provider === "tavily" ? tavilyConfig.maxResults : undefined) ??
+        search?.maxResults ??
+        undefined;
       const country = readStringParam(params, "country");
       const search_lang = readStringParam(params, "search_lang");
       const ui_lang = readStringParam(params, "ui_lang");
@@ -783,6 +807,7 @@ export function createWebSearchTool(options?: {
           perplexityAuth?.apiKey,
         ),
         perplexityModel: resolvePerplexityModel(perplexityConfig),
+        tavilyIncludeRawContent: tavilyConfig.includeRawContent,
       });
       return jsonResult(result);
     },

--- a/openclawd-2026.2.3/src/agents/tools/web-search.ts
+++ b/openclawd-2026.2.3/src/agents/tools/web-search.ts
@@ -18,12 +18,13 @@ import {
   writeCache,
 } from "./web-shared.js";
 
-const SEARCH_PROVIDERS = ["brave", "perplexity", "duckduckgo"] as const;
+const SEARCH_PROVIDERS = ["brave", "perplexity", "duckduckgo", "tavily"] as const;
 const DEFAULT_SEARCH_COUNT = 5;
 const MAX_SEARCH_COUNT = 10;
 
 const BRAVE_SEARCH_ENDPOINT = "https://api.search.brave.com/res/v1/web/search";
 const DUCKDUCKGO_HTML_ENDPOINT = "https://html.duckduckgo.com/html/";
+const TAVILY_SEARCH_ENDPOINT = "https://api.tavily.com/search";
 const DEFAULT_PERPLEXITY_BASE_URL = "https://openrouter.ai/api/v1";
 const PERPLEXITY_DIRECT_BASE_URL = "https://api.perplexity.ai";
 const DEFAULT_PERPLEXITY_MODEL = "perplexity/sonar-pro";
@@ -174,6 +175,14 @@ function missingSearchKeyPayload(provider: (typeof SEARCH_PROVIDERS)[number]) {
       docs: "https://docs.openclaw.ai/tools/web",
     };
   }
+  if (provider === "tavily") {
+    return {
+      error: "missing_tavily_api_key",
+      message:
+        "web_search (tavily) needs an API key. Set TAVILY_API_KEY in the Gateway environment, or configure tools.web.search.tavily.apiKey.",
+      docs: "https://docs.openclaw.ai/tools/web",
+    };
+  }
   return {
     error: "missing_brave_api_key",
     message: `web_search needs a Brave Search API key. Run \`${formatCliCommand("openclaw configure --section web")}\` to store it, or set BRAVE_API_KEY in the Gateway environment.`,
@@ -191,6 +200,9 @@ function resolveSearchProvider(search?: WebSearchConfig): (typeof SEARCH_PROVIDE
   }
   if (raw === "duckduckgo" || raw === "ddg") {
     return "duckduckgo";
+  }
+  if (raw === "tavily") {
+    return "tavily";
   }
   if (raw === "brave") {
     return "brave";
@@ -453,6 +465,62 @@ async function runDuckDuckGoSearch(params: {
   }
 }
 
+type TavilySearchResult = {
+  title?: string;
+  url?: string;
+  content?: string;
+};
+
+type TavilySearchResponse = {
+  results?: TavilySearchResult[];
+};
+
+function resolveTavilyApiKey(search?: WebSearchConfig): string | undefined {
+  const fromConfig =
+    search && "tavily" in search && typeof search.tavily === "object" && search.tavily
+      ? typeof (search.tavily as Record<string, unknown>).apiKey === "string"
+        ? ((search.tavily as Record<string, unknown>).apiKey as string).trim()
+        : ""
+      : "";
+  const fromEnv = (process.env.TAVILY_API_KEY ?? "").trim();
+  return fromConfig || fromEnv || undefined;
+}
+
+async function runTavilySearch(params: {
+  query: string;
+  count: number;
+  apiKey: string;
+  timeoutSeconds: number;
+}): Promise<Array<{ title: string; url: string; description: string; siteName?: string }>> {
+  const res = await proxyFetch(TAVILY_SEARCH_ENDPOINT, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      api_key: params.apiKey,
+      query: params.query,
+      max_results: params.count,
+      search_depth: "basic",
+    }),
+    signal: withTimeout(undefined, params.timeoutSeconds * 1000),
+  });
+
+  if (!res.ok) {
+    const detail = await readResponseText(res);
+    throw new Error(`Tavily Search API error (${res.status}): ${detail || res.statusText}`);
+  }
+
+  const data = (await res.json()) as TavilySearchResponse;
+  const results = Array.isArray(data.results) ? data.results : [];
+  return results.map((entry) => ({
+    title: entry.title ?? "",
+    url: entry.url ?? "",
+    description: entry.content ?? "",
+    siteName: resolveSiteName(entry.url),
+  }));
+}
+
 async function runPerplexitySearch(params: {
   query: string;
   apiKey?: string;
@@ -558,6 +626,24 @@ async function runWebSearch(params: {
     return payload;
   }
 
+  if (params.provider === "tavily") {
+    const tavilyResults = await runTavilySearch({
+      query: params.query,
+      count: params.count,
+      apiKey: params.apiKey!,
+      timeoutSeconds: params.timeoutSeconds,
+    });
+    const payload = {
+      query: params.query,
+      provider: params.provider,
+      count: tavilyResults.length,
+      tookMs: Date.now() - start,
+      results: tavilyResults,
+    };
+    writeCache(SEARCH_CACHE, cacheKey, payload, params.cacheTtlMs);
+    return payload;
+  }
+
   if (params.provider !== "brave") {
     throw new Error("Unsupported web search provider.");
   }
@@ -634,7 +720,9 @@ export function createWebSearchTool(options?: {
   const description =
     provider === "perplexity"
       ? "Search the web using Perplexity Sonar (direct or via OpenRouter). Returns AI-synthesized answers with citations from real-time web search."
-      : "Search the web using Brave Search API. Supports region-specific and localized search via country and language parameters. Returns titles, URLs, and snippets for fast research.";
+      : provider === "tavily"
+        ? "Search the web using Tavily Search API. Returns titles, URLs, and content snippets optimized for LLM consumption."
+        : "Search the web using Brave Search API. Supports region-specific and localized search via country and language parameters. Returns titles, URLs, and snippets for fast research.";
 
   return {
     label: "Web Search",
@@ -645,7 +733,11 @@ export function createWebSearchTool(options?: {
       const perplexityAuth =
         provider === "perplexity" ? resolvePerplexityApiKey(perplexityConfig) : undefined;
       const apiKey =
-        provider === "perplexity" ? perplexityAuth?.apiKey : resolveSearchApiKey(search);
+        provider === "perplexity"
+          ? perplexityAuth?.apiKey
+          : provider === "tavily"
+            ? resolveTavilyApiKey(search)
+            : resolveSearchApiKey(search);
 
       if (!apiKey && provider !== "duckduckgo") {
         return jsonResult(missingSearchKeyPayload(provider));

--- a/openclawd-2026.2.3/src/config/schema.ts
+++ b/openclawd-2026.2.3/src/config/schema.ts
@@ -472,7 +472,7 @@ const FIELD_HELP: Record<string, string> = {
   "tools.message.broadcast.enabled": "Enable broadcast action (default: true).",
   "tools.web.search.enabled": "Enable the web_search tool (requires a provider API key).",
   "tools.web.search.provider":
-    'Search provider ("brave", "perplexity", or "duckduckgo"). DuckDuckGo is free and requires no API key.',
+    'Search provider ("brave", "perplexity", "duckduckgo", or "tavily"). DuckDuckGo is free and requires no API key.',
   "tools.web.search.apiKey": "Brave Search API key (fallback: BRAVE_API_KEY env var).",
   "tools.web.search.maxResults": "Default number of results to return (1-10).",
   "tools.web.search.timeoutSeconds": "Timeout in seconds for web_search requests.",

--- a/openclawd-2026.2.3/src/config/types.tools.ts
+++ b/openclawd-2026.2.3/src/config/types.tools.ts
@@ -336,8 +336,8 @@ export type ToolsConfig = {
     search?: {
       /** Enable web search tool (default: true when API key is present). */
       enabled?: boolean;
-      /** Search provider ("brave", "perplexity", or "duckduckgo"). DuckDuckGo is free and requires no API key. */
-      provider?: "brave" | "perplexity" | "duckduckgo" | "ddg";
+      /** Search provider ("brave", "perplexity", "duckduckgo", or "tavily"). DuckDuckGo is free and requires no API key. */
+      provider?: "brave" | "perplexity" | "duckduckgo" | "ddg" | "tavily";
       /** Brave Search API key (optional; defaults to BRAVE_API_KEY env var). */
       apiKey?: string;
       /** Default search results count (1-10). */
@@ -346,6 +346,15 @@ export type ToolsConfig = {
       timeoutSeconds?: number;
       /** Cache TTL in minutes for search results. */
       cacheTtlMinutes?: number;
+      /** Tavily-specific configuration (used when provider="tavily"). */
+      tavily?: {
+        /** API key for Tavily (defaults to TAVILY_API_KEY env var). */
+        apiKey?: string;
+        /** Max number of results (default: 5). */
+        maxResults?: number;
+        /** Include raw content in results. */
+        includeRawContent?: boolean;
+      };
       /** Perplexity-specific configuration (used when provider="perplexity"). */
       perplexity?: {
         /** API key for Perplexity or OpenRouter (defaults to PERPLEXITY_API_KEY or OPENROUTER_API_KEY env var). */

--- a/openclawd-2026.2.3/src/config/zod-schema.agent-runtime.ts
+++ b/openclawd-2026.2.3/src/config/zod-schema.agent-runtime.ts
@@ -177,6 +177,7 @@ export const ToolsWebSearchSchema = z
         z.literal("perplexity"),
         z.literal("duckduckgo"),
         z.literal("ddg"),
+        z.literal("tavily"),
       ])
       .optional(),
     apiKey: z.string().optional(),
@@ -188,6 +189,14 @@ export const ToolsWebSearchSchema = z
         apiKey: z.string().optional(),
         baseUrl: z.string().optional(),
         model: z.string().optional(),
+      })
+      .strict()
+      .optional(),
+    tavily: z
+      .object({
+        apiKey: z.string().optional(),
+        maxResults: z.number().int().positive().optional(),
+        includeRawContent: z.boolean().optional(),
       })
       .strict()
       .optional(),


### PR DESCRIPTION
## Summary

- Added **Tavily** as a fourth selectable web search provider (`tools.web.search.provider: "tavily"`), alongside existing Brave, Perplexity, and DuckDuckGo options
- No existing providers were removed or modified — this is a purely additive change
- Tavily search uses the REST API directly via the existing `proxyFetch` helper (no new npm dependency required)

## Changes

### `openclawd-2026.2.3/src/agents/tools/web-search.ts`
- Extended `SEARCH_PROVIDERS` tuple to include `"tavily"`
- Added `TAVILY_SEARCH_ENDPOINT` constant
- Added `TavilyConfig` type, `resolveTavilyConfig()`, and `resolveTavilyApiKey()` helpers
- Implemented `runTavilySearch()` calling Tavily `/search` endpoint, mapping results to the standard shape (title, url, description, siteName)
- Added `"tavily"` dispatch branch in `runWebSearch()` with result caching
- Added missing API key error payload for the Tavily case
- Updated `resolveSearchProvider()` to recognize `"tavily"`
- Updated tool description string for Tavily provider
- Resolved Tavily API key in `createWebSearchTool()` execute handler

### `openclawd-2026.2.3/src/config/types.tools.ts`
- Extended `provider` union type to include `"tavily"`
- Added optional `tavily?: { apiKey?, maxResults?, includeRawContent? }` config block

### `openclawd-2026.2.3/src/config/zod-schema.agent-runtime.ts`
- Added `z.literal("tavily")` to the provider union
- Added `tavily` Zod sub-schema with `apiKey`, `maxResults`, and `includeRawContent` fields

### `openclawd-2026.2.3/src/config/schema.ts`
- Updated UI hint text for `tools.web.search.provider` to list `"tavily"` as a valid option

## Environment variable changes
- **Added**: `TAVILY_API_KEY` — Tavily Search API key, read by `resolveTavilyApiKey()` as fallback when not set in config

## Notes for reviewers
- No new npm dependencies added — Tavily REST API is called directly via the existing `proxyFetch` helper
- All existing providers (Brave, Perplexity, DuckDuckGo) remain unchanged
- The `freshness` parameter validation correctly rejects Tavily (Brave-only feature)


### Automated Review

- Passed after 2 attempt(s)
- Final review: All 4 stated issues from the prior review are correctly addressed. The Tavily provider implementation is functionally correct, consistent with existing codebase patterns, and introduces no regressions. Config types, Zod schemas, and field-help text are updated consistently across all relevant files. Only two minor observations remain.
